### PR TITLE
Re #188: Disable previous / next link checks in object feature spec

### DIFF
--- a/spec/features/object_spec.rb
+++ b/spec/features/object_spec.rb
@@ -18,20 +18,23 @@ RSpec.feature 'Object page', :type => :feature do
       expect(page).to have_selector('.next')
       page_title = page.title
 
-      # next
+      # #click on these links in capybara does not trigger the POST action to
+      # the data-context-href attribute (/record/abc/123/track) of the <a>
+      # elements, and so always fail
+#      # next
 
-      find('.next a').click
-      sleep 2
+#      find('.next a').click
+#      sleep 2
 
-      expect(page).to have_css('.next a')
-      expect(page).to have_css('.previous a')
+#      expect(page).to have_css('.next a')
+#      expect(page).to have_css('.previous a')
 
-      assert page.title != page_title
+#      assert page.title != page_title
 
-      # prev
+#      # prev
 
-      find('.previous a').click
-      assert page.title == page_title
+#      find('.previous a').click
+#      assert page.title == page_title
     end
   end
 end


### PR DESCRIPTION
This feature spec always fails because: clicking on the next and previous links on object pages with Capybara does not for some reason trigger the POST action to the data-context-href attribute (/record/abc/123/track) of the <a> elements, even though it does trigger it from the search results page.

Those expectations have here been commented out.

@andyjmaclean if you are able to fix this feature spec to get it working, please do. Otherwise, please just merge as-is, as we may in future rework the next/previous link implementation to not be dependent on JS.