### PR TITLE
Re: #228 similar items ajax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'europeana-api',
 # Use the Europeana styleguide for UI components (templates)
 gem 'europeana-styleguide',
   github: 'europeana/europeana-styleguide-ruby',
-  ref: '90725fc008'
+  ref: 'c5f5cecee9'
 
 # Use a forked version of stache with a downstream fix, until merged upstream
 # @see https://github.com/agoragames/stache/pull/53

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,8 +10,8 @@ GIT
 
 GIT
   remote: git://github.com/europeana/europeana-styleguide-ruby.git
-  revision: 90725fc00806138eac4c91cc245e25d5a6c14450
-  ref: 90725fc008
+  revision: c5f5cecee9591353ba2d6983b6f3022e897e89ef
+  ref: c5f5cecee9
   specs:
     europeana-styleguide (0.0.2)
       activesupport (~> 4.0)

--- a/app/views/templates/search/search_object.rb
+++ b/app/views/templates/search/search_object.rb
@@ -76,8 +76,8 @@ module Templates
                   url: 'what',
                   fields: ['aggregations.edmUgc'],
                   collected: collect_values(['concepts.prefLabel']).size == 0 ? [] : document.concepts.map do |concept|
-                    concept.fetch('prefLabel', nil).compact.join('')
-                  end,
+                    concept.fetch('prefLabel', nil)
+                  end.compact.join(''),
                   override_val: 'true',
                   overrides: [
                     {


### PR DESCRIPTION
*Use ajax to load (non-initial) similar items.  The first four items are loaded normally for no-js.
*Fixed another flatten.join error in search_object

