### PR TITLE
Re #300: Update Ruby to version 2.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ notifications:
 sudo: false
 language: ruby
 rvm:
-  - 2.2.1
+  - 2.2.2
 before_script:
   - "mysql -e 'create database europeana_channels_blacklight_test;'"
   - "cp ./config/database.travis.yml ./config/database.yml"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.2.1'
+ruby '2.2.2'
 gem 'rails', '4.2.1'
 
 # Use Europeana's REST API as the Blacklight catalog data source


### PR DESCRIPTION
Ruby 2.2.1 is not supported in the CloudFoundry buildpacks used to build this application on Anynines.

It is therefore necessary to upgrade to Ruby 2.2.2.