### PR TITLE
Do not convert to symbols incoming URL parameters

### DIFF
--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -43,8 +43,7 @@ class ChannelsController < ApplicationController
   end
 
   def find_channel
-    id = (params[:action] == 'index' ? :home : params[:id].to_sym)
-    @channel ||= Channel.find(id)
+    @channel ||= Channel.find(params[:id])
   end
 
   def channel_not_found

--- a/app/controllers/concerns/europeana/channels.rb
+++ b/app/controllers/concerns/europeana/channels.rb
@@ -18,7 +18,7 @@ module Europeana
     # @return [Channel]
     def current_channel
       return nil unless within_channel?
-      Channel.find(params[:id].to_sym)
+      Channel.find(params[:id])
     end
 
     ##
@@ -27,7 +27,7 @@ module Europeana
     # @return [Channel]
     def current_search_channel
       return nil unless current_search_session.query_params[:id]
-      Channel.find(current_search_session.query_params[:id].to_sym)
+      Channel.find(current_search_session.query_params[:id])
     end
 
     ##

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -4,8 +4,8 @@
 # @todo Use ActiveModel
 class Channel
   # @!attribute [r] id
-  #   @return [Symbol] the ID of the Channel
-  #   @example :music
+  #   @return [String] the ID of the Channel
+  #   @example 'music'
   attr_reader :id
 
   # @!attribute [rw] config
@@ -22,10 +22,10 @@ class Channel
     channel
   end
 
-  # @param [Symbol] id The Channel ID
+  # @param [String] id The Channel ID
   def initialize(id)
-    unless id.is_a?(Symbol)
-      fail ArgumentError, "Channel ID must be a Symbol, but is a #{id.class}"
+    unless id.is_a?(String)
+      fail ArgumentError, "Channel ID must be a String, but is a #{id.class}"
     end
     @id = id
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,7 +36,7 @@ module Europeana
 
       # Load Channels configuration files from config/channels/*.yml files
       config.channels = Dir[Rails.root.join('config', 'channels', '*.yml').to_s].each_with_object({}) do |yml, hash|
-        channel = File.basename(yml, '.yml').to_sym
+        channel = File.basename(yml, '.yml')
         hash[channel] = YAML::load_file(yml)
       end
     end

--- a/spec/controllers/channels_controller_spec.rb
+++ b/spec/controllers/channels_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe ChannelsController, type: :controller do
     end
 
     context 'with id=[known channel]' do
-      let(:channel_id) { Europeana::Portal::Application.config.channels.keys.reject { |k| k == :home }.first }
+      let(:channel_id) { Europeana::Portal::Application.config.channels.keys.reject { |k| k == 'home' }.first }
       before do
 #        channel = class_double(Channel).as_stubbed_const
 #        allow(channel).to receive(:find).and_return(instance_double('Channel'))

--- a/spec/helpers/channels_helper_spec.rb
+++ b/spec/helpers/channels_helper_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ChannelsHelper, type: :helper do
       expect(subject).to eq(Europeana::Portal::Application.config.channels.keys.sort)
     end
     it { is_expected.to be_instance_of(Array) }
-    it { is_expected.to include(:home) }
+    it { is_expected.to include('home') }
   end
   
   describe '#within_channel?' do

--- a/spec/models/channel_spec.rb
+++ b/spec/models/channel_spec.rb
@@ -4,19 +4,19 @@ RSpec.describe Channel, type: :model do
   before do
     app = class_double('Europeana::Portal::Application').as_stubbed_const
     app_config = double('app config')
-    channels_config = { :art => { query: 'pictures' }, :music => { query: 'sounds' } }
+    channels_config = { 'art' => { query: 'pictures' }, 'music' => { query: 'sounds' } }
     allow(app_config).to receive(:channels).and_return(channels_config)
     allow(app).to receive(:config).and_return(app_config)
   end
 
   describe '.find' do
     it 'validates requested channel' do
-      expect { Channel.find(:unknown) }.to raise_error(Channels::Errors::NoChannelConfiguration)
+      expect { Channel.find('unknown') }.to raise_error(Channels::Errors::NoChannelConfiguration)
     end
 
     it 'looks to app config for a channel' do
       expect(Europeana::Portal::Application).to receive(:config)
-      channel = Channel.find(:art)
+      channel = Channel.find('art')
       expect(channel).to be_a(Channel)
       expect(channel.config).to eq({ query: 'pictures' })
     end
@@ -24,14 +24,14 @@ RSpec.describe Channel, type: :model do
 
   describe '#initialize' do
     it 'requires Symbol arg' do
-      expect { Channel.new('art') }.to raise_error(/Channel ID must be a Symbol/)
-      expect { Channel.new(:art) }.not_to raise_error
+      expect { Channel.new(:art) }.to raise_error(/Channel ID must be a String/)
+      expect { Channel.new('art') }.not_to raise_error
     end
   end
 
   describe '#method_missing' do
     it 'looks up data in config' do
-      channel = Channel.new(:history)
+      channel = Channel.new('history')
       channel.config = { query: 'old' }
       expect { channel.query }.not_to raise_error
       expect(channel.query).to eq('old')


### PR DESCRIPTION
Conversion to symbols of URL parameters is unsafe.