### PR TITLE
Re #316: Make MIME types available to front end before rendering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ rvm:
   - 2.2.2
 before_script:
   - "mysql -e 'create database europeana_channels_blacklight_test;'"
-  - "cp -r ./deploy/travis/* ."
+  - "cp -r ./deploy/travis/. ."
 env:
   - RAILS_ENV=test

--- a/app/controllers/portal_controller.rb
+++ b/app/controllers/portal_controller.rb
@@ -20,6 +20,7 @@ class PortalController < ApplicationController
   def show
     @response, @document = fetch_with_hierarchy(doc_id)
     _mlt_response, @similar = more_like_this(@document, nil, per_page: 4)
+    @mime_type = media_mime_type(@document)
 
     respond_to do |format|
       format.html do

--- a/app/views/templates/search/search_object.rb
+++ b/app/views/templates/search/search_object.rb
@@ -676,7 +676,7 @@ module Templates
         else
           item['is_unkown_type'] = media_type
         end
-        if edm_is_shown_by_download_url.size > 0
+        if edm_is_shown_by_download_url.present?
           item['download'] = {
             url: edm_is_shown_by_download_url,
             text: t('site.object.actions.download')

--- a/deploy/travis/.env
+++ b/deploy/travis/.env
@@ -1,0 +1,3 @@
+EDM_IS_SHOWN_BY_PROXY=http://proxy.example.com
+EUROPEANA_API_KEY=abc123
+EUROPEANA_STYLEGUIDE_CDN=http://styleguide.example.com

--- a/spec/controllers/channels_controller_spec.rb
+++ b/spec/controllers/channels_controller_spec.rb
@@ -47,11 +47,6 @@ RSpec.describe ChannelsController, type: :controller do
 
     context 'with id=[known channel]' do
       let(:channel_id) { Europeana::Portal::Application.config.channels.keys.reject { |k| k == 'home' }.first }
-      before do
-#        channel = class_double(Channel).as_stubbed_const
-#        allow(channel).to receive(:find).and_return(instance_double('Channel'))
-        # stub portal channels config to know about this channel
-      end
 
       context 'without search params' do
         let(:params) { { id: channel_id } }
@@ -60,8 +55,8 @@ RSpec.describe ChannelsController, type: :controller do
           expect(an_api_search_request).not_to have_been_made
         end
 
-        it 'gets RSS blog posts' do
-          expect(a_europeana_blog_request).to have_been_made
+        it 'does not get RSS blog posts' do
+          expect(a_europeana_blog_request).not_to have_been_made
         end
 
         it 'renders channels landing template' do

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe HomeController, type: :controller do
       expect(an_api_search_request).to have_been_made
     end
 
-    it 'gets RSS blog posts' do
-      expect(a_europeana_blog_request).to have_been_made
+    it 'does not get RSS blog posts' do
+      expect(a_europeana_blog_request).not_to have_been_made
     end
 
     it 'renders the homepage Mustache template' do

--- a/spec/controllers/portal_controller_spec.rb
+++ b/spec/controllers/portal_controller_spec.rb
@@ -64,8 +64,11 @@ RSpec.describe PortalController, type: :controller do
     it_behaves_like 'a more like this API request'
     it_behaves_like 'a hierarchy API request'
 
-    it 'requests the mime-type from the proxy service' do
+    it 'requests the MIME type from the proxy service' do
       expect(a_media_proxy_request_for(record_id)).to have_been_made
+    end
+    it 'assigns the MIME type to @mime_type' do
+      expect(assigns(:mime_type)).to eq('application/pdf')
     end
     it 'does not break if there is no edm:isShownBy'
     it 'does not make a request to the service if record has no edm:isshownby'

--- a/spec/controllers/portal_controller_spec.rb
+++ b/spec/controllers/portal_controller_spec.rb
@@ -56,14 +56,29 @@ RSpec.describe PortalController, type: :controller do
     before do
       get :show, params
     end
+
     let(:params) { { id: 'abc/123' } }
     let(:record_id) { '/' + params[:id] }
+
     it_behaves_like 'a record API request'
     it_behaves_like 'a more like this API request'
     it_behaves_like 'a hierarchy API request'
-    context 'when format is HTML' do
-      it 'renders the object display page'
+
+    it 'requests the mime-type from the proxy service' do
+      expect(a_media_proxy_request_for(record_id)).to have_been_made
     end
+    it 'does not break if there is no edm:isShownBy'
+    it 'does not make a request to the service if record has no edm:isshownby'
+    it 'checks that the edm:isShownBy value is sane, i.e. http:// or https://'
+    it 'caches the mime-type response'
+
+    context 'when format is HTML' do
+      let(:params) { { id: 'abc/123', format: 'html' } }
+      it 'renders the object display page' do
+        expect(response).to render_template('templates/Search/Search-object')
+      end
+    end
+
     context 'when format is JSON' do
       it 'requests JSON-LD from the API'
       it 'renders the API JSON-LD response'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,7 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
 require 'coveralls'
-Coveralls.wear!
+Coveralls.wear! unless Coveralls.will_run?.nil?
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/support/europeana_api_helper.rb
+++ b/spec/support/europeana_api_helper.rb
@@ -20,7 +20,7 @@ module EuropeanaAPIHelper
         to_return do |request|
           id = request.uri.path.match(%r{/record(/[^/]+/[^/]+).json})[1]
           {
-            body: '{"success":true,"object":{"about": "' + id + '", "title":["' + id + '"], "proxies": [{"dcCreator":{"def":["Mister Smith"]}}]}}',
+            body: '{"success":true,"object":{"about": "' + id + '", "title":["' + id + '"], "proxies": [{"dcCreator":{"def":["Mister Smith"]}}], "aggregations": [{"edmIsShownBy":"http://provider.example.com/ ' + id + '"}]}}',
             status: 200,
             headers: { 'Content-Type' => 'text/json' }
           }
@@ -32,6 +32,11 @@ module EuropeanaAPIHelper
         to_return(body: '{"success":false,"message":"This record has no hierarchical structure!"}',
                   status: 200,
                   headers: { 'Content-Type' => 'text/json' })
+
+      # Media proxy
+      stub_request(:head, %r{#{ENV['EDM_IS_SHOWN_BY_PROXY']}/[^/]+/[^/]+}).
+        to_return(status: 200,
+                  headers: { 'Content-Type' => 'application/pdf' })
     end
   end
 
@@ -52,5 +57,9 @@ module EuropeanaAPIHelper
   def an_api_hierarchy_request_for(id)
     a_request(:get, %r{#{Europeana::API.url}/record#{id}/(self|parent|children|ancestor-self-siblings|precee?ding-siblings|following-siblings).json}).
       with(query: hash_including(wskey: api_key))
+  end
+
+  def a_media_proxy_request_for(id)
+    a_request(:head, ENV['EDM_IS_SHOWN_BY_PROXY'] + id)
   end
 end

--- a/spec/support/europeana_api_helper.rb
+++ b/spec/support/europeana_api_helper.rb
@@ -9,14 +9,14 @@ module EuropeanaAPIHelper
       end.join(',')
 
       stub_request(:get, Europeana::API.url + '/search.json').
-        with(query: hash_including(wskey: api_key)).
+        with(query: hash_including(wskey: ENV['EUROPEANA_API_KEY'])).
         to_return(body: '{"success":true,"itemsCount":' + items.size.to_s + ',"totalResults":' + items.size.to_s + ',"items":[' + items + ']}',
                   status: 200,
                   headers: { 'Content-Type' => 'text/json' })
 
       # API Record
       stub_request(:get, %r{#{Europeana::API.url}/record/[^/]+/[^/]+.json}).
-        with(query: hash_including(wskey: api_key)).
+        with(query: hash_including(wskey: ENV['EUROPEANA_API_KEY'])).
         to_return do |request|
           id = request.uri.path.match(%r{/record(/[^/]+/[^/]+).json})[1]
           {
@@ -28,7 +28,7 @@ module EuropeanaAPIHelper
 
       # Hierarchy API
       stub_request(:get, %r{#{Europeana::API.url}/record/[^/]+/[^/]+/(self|parent|children|ancestor-self-siblings|precee?ding-siblings|following-siblings).json}).
-        with(query: hash_including(wskey: api_key)).
+        with(query: hash_including(wskey: ENV['EUROPEANA_API_KEY'])).
         to_return(body: '{"success":false,"message":"This record has no hierarchical structure!"}',
                   status: 200,
                   headers: { 'Content-Type' => 'text/json' })
@@ -40,23 +40,19 @@ module EuropeanaAPIHelper
     end
   end
 
-  def api_key
-    ENV['EUROPEANA_API_KEY']
-  end
-
   def an_api_search_request
     a_request(:get, Europeana::API.url + '/search.json').
-      with(query: hash_including(wskey: api_key))
+      with(query: hash_including(wskey: ENV['EUROPEANA_API_KEY']))
   end
 
   def an_api_record_request_for(id)
     a_request(:get, Europeana::API.url + "/record#{id}.json").
-      with(query: hash_including(wskey: api_key))
+      with(query: hash_including(wskey: ENV['EUROPEANA_API_KEY']))
   end
 
   def an_api_hierarchy_request_for(id)
     a_request(:get, %r{#{Europeana::API.url}/record#{id}/(self|parent|children|ancestor-self-siblings|precee?ding-siblings|following-siblings).json}).
-      with(query: hash_including(wskey: api_key))
+      with(query: hash_including(wskey: ENV['EUROPEANA_API_KEY']))
   end
 
   def a_media_proxy_request_for(id)

--- a/spec/support/europeana_api_helper.rb
+++ b/spec/support/europeana_api_helper.rb
@@ -9,14 +9,14 @@ module EuropeanaAPIHelper
       end.join(',')
 
       stub_request(:get, Europeana::API.url + '/search.json').
-        with(query: hash_including(wskey: 'test')).
+        with(query: hash_including(wskey: api_key)).
         to_return(body: '{"success":true,"itemsCount":' + items.size.to_s + ',"totalResults":' + items.size.to_s + ',"items":[' + items + ']}',
                   status: 200,
                   headers: { 'Content-Type' => 'text/json' })
 
       # API Record
       stub_request(:get, %r{#{Europeana::API.url}/record/[^/]+/[^/]+.json}).
-        with(query: hash_including(wskey: 'test')).
+        with(query: hash_including(wskey: api_key)).
         to_return do |request|
           id = request.uri.path.match(%r{/record(/[^/]+/[^/]+).json})[1]
           {
@@ -28,25 +28,29 @@ module EuropeanaAPIHelper
 
       # Hierarchy API
       stub_request(:get, %r{#{Europeana::API.url}/record/[^/]+/[^/]+/(self|parent|children|ancestor-self-siblings|precee?ding-siblings|following-siblings).json}).
-        with(query: hash_including(wskey: 'test')).
+        with(query: hash_including(wskey: api_key)).
         to_return(body: '{"success":false,"message":"This record has no hierarchical structure!"}',
                   status: 200,
                   headers: { 'Content-Type' => 'text/json' })
     end
   end
 
+  def api_key
+    ENV['EUROPEANA_API_KEY']
+  end
+
   def an_api_search_request
     a_request(:get, Europeana::API.url + '/search.json').
-      with(query: hash_including(wskey: 'test'))
+      with(query: hash_including(wskey: api_key))
   end
 
   def an_api_record_request_for(id)
     a_request(:get, Europeana::API.url + "/record#{id}.json").
-      with(query: hash_including(wskey: 'test'))
+      with(query: hash_including(wskey: api_key))
   end
 
   def an_api_hierarchy_request_for(id)
     a_request(:get, %r{#{Europeana::API.url}/record#{id}/(self|parent|children|ancestor-self-siblings|precee?ding-siblings|following-siblings).json}).
-      with(query: hash_including(wskey: 'test'))
+      with(query: hash_including(wskey: api_key))
   end
 end


### PR DESCRIPTION
This works by:

1. Sending an HTTP HEAD request to the media proxy service
2. Caching the response in Redis, indefinitely

This will require additional HTTP request(s) of unpredictable duration, which will have to be made by the Ruby app before any response is sent to the client (the first time each object is requested). This is not ideal. *But*, this is only an interim strategy until we have such technical metadata available via the API, later in the year.

On the object pages, the MIME type is set in the variable `@mime_type`