### PR TITLE
Re #308: Feature specs for search box behaviour.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rails', '4.2.3'
 # Use the Europeana styleguide for UI components (templates)
 gem 'europeana-styleguide',
   github: 'europeana/europeana-styleguide-ruby',
-  ref: '316ae8349a'
+  ref: '1ea913dc99'
 
 # Use a forked version of stache with a downstream fix, until merged upstream
 # @see https://github.com/agoragames/stache/pull/53

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: git://github.com/europeana/europeana-styleguide-ruby.git
-  revision: 316ae8349a9a2725d1d3049445cf0cfdaa459b70
-  ref: 316ae8349a
+  revision: 1ea913dc995fd09671be6fb309874ad6f8f38598
+  ref: 1ea913dc99
   specs:
     europeana-styleguide (0.0.2)
       activesupport (~> 4.0)

--- a/spec/capybara_helper.rb
+++ b/spec/capybara_helper.rb
@@ -25,7 +25,7 @@ else
   Capybara.configure do |config|
     config.javascript_driver = :poltergeist
     config.default_wait_time = 10
-    config.default_selector  = :css
+    config.default_selector = :css
   end
 
   RSpec.configure do |config|

--- a/spec/capybara_helper.rb
+++ b/spec/capybara_helper.rb
@@ -2,41 +2,31 @@
 require 'capybara/rspec'
 require 'capybara/rails'
 
-Capybara.asset_host = 'http://develop.styleguide.eanadev.org'
-
 if ENV['CAPYBARA_DRIVER'] == 'selenium'
   require 'selenium-webdriver'
+
   Capybara.register_driver :selenium do |app|
     Capybara::Selenium::Driver.new(app, browser: (ENV['CAPYBARA_BROWSER'] || :firefox).to_sym)
   end
-  Capybara.default_driver = :selenium
+
   Capybara.javascript_driver = :selenium
 else
   require 'capybara/poltergeist'
-  Capybara.configure do |config|
-    config.default_driver = :poltergeist
-    config.javascript_driver = :poltergeist
-    config.current_driver = :poltergeist
-    config.run_server = true
-    config.default_wait_time = 10
-  end
 
   Capybara.register_driver :poltergeist do |app|
     Capybara::Poltergeist::Driver.new(app,
       phantomjs_options: [
-        '--debug=no',
-        '--load-images=no',
-        '--ignore-ssl-errors=true',
-        '--local-to-remote-url-access=yes',
-        '--ssl-protocol=TLSv1',
-        '--web-security=false',
-         '--local-to-remote-url-access=true'
+        '--local-to-remote-url-access=true'
       ],
-    extensions: ['http://ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js'])
+      js_errors: true
+    )
   end
-    
-  Capybara.javascript_driver = :poltergeist
-  Capybara.default_selector  = :css
+
+  Capybara.configure do |config|
+    config.javascript_driver = :poltergeist
+    config.default_wait_time = 10
+    config.default_selector  = :css
+  end
 
   RSpec.configure do |config|
     # Include Capybara for integration testing.

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -23,5 +23,24 @@ RSpec.feature 'Search page', :type => :feature do
       item_count = page.evaluate_script '$(".results-list ol.result-items li").length'
       expect(item_count).to be_between(1, 24)
     end
+
+    it 'permits empty searches' do
+      visit '/'
+      sleep 1
+      fill_in('q', with: '')
+      find('button.search-submit').click
+      sleep 1
+      expect(current_path).to eq('/search')
+    end
+
+    it 'does not sumit placeholder text' do
+      visit '/'
+      sleep 1
+      fill_in('q', with: '')
+      find('button.search-submit').click
+      sleep 1
+      placeholder = find('.searchbar input.search-input')[:placeholder]
+      expect(page.all('li.search-tag', text: placeholder)).to be_blank
+    end
   end
 end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -39,8 +39,6 @@ RSpec.feature 'Search page', :type => :feature do
       fill_in('q', with: 'paris')
       find('button.search-submit').click
 
-      #find('button.search-submit').click
-
       expect(page.all('li.search-tag').size).to eq(1)
     end
 

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature 'Search page', :type => :feature do
       fill_in('q', with: 'paris')
       find('button.search-submit').click
 
-      find('button.search-submit').click
+      #find('button.search-submit').click
 
       expect(page.all('li.search-tag').size).to eq(1)
     end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature 'Search page', :type => :feature do
       expect(current_path).to eq('/search')
     end
 
-    it 'does not sumit placeholder text' do
+    it 'does not submit placeholder text' do
       visit '/'
       sleep 3
       fill_in('q', with: '')

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -26,20 +26,32 @@ RSpec.feature 'Search page', :type => :feature do
 
     it 'permits empty searches' do
       visit '/'
-      sleep 3
+
       fill_in('q', with: '')
       find('button.search-submit').click
-      sleep 2
+
       expect(current_path).to eq('/search')
+    end
+
+    it 'ignores 2nd empty search' do
+      visit '/'
+
+      fill_in('q', with: 'paris')
+      find('button.search-submit').click
+
+      find('button.search-submit').click
+
+      expect(page.all('li.search-tag').size).to eq(1)
     end
 
     it 'does not submit placeholder text' do
       visit '/'
-      sleep 3
+
       fill_in('q', with: '')
       find('button.search-submit').click
-      sleep 2
+
       placeholder = find('.searchbar input.search-input')[:placeholder]
+
       expect(page.all('li.search-tag', text: placeholder)).to be_blank
     end
   end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -26,19 +26,19 @@ RSpec.feature 'Search page', :type => :feature do
 
     it 'permits empty searches' do
       visit '/'
-      sleep 1
+      sleep 3
       fill_in('q', with: '')
       find('button.search-submit').click
-      sleep 1
+      sleep 2
       expect(current_path).to eq('/search')
     end
 
     it 'does not sumit placeholder text' do
       visit '/'
-      sleep 1
+      sleep 3
       fill_in('q', with: '')
       find('button.search-submit').click
-      sleep 1
+      sleep 2
       placeholder = find('.searchbar input.search-input')[:placeholder]
       expect(page.all('li.search-tag', text: placeholder)).to be_blank
     end


### PR DESCRIPTION
These feature specs ensure that:

1. Empty searches are permitted
2. Placeholder text is not submitted when an empty search is performed