### PR TITLE
Re #337: Read relative URL root from ENV

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,9 @@ module Europeana
       # Use Delayed::Job as the job queue adapter
       config.active_job.queue_adapter = :delayed_job
 
+      # Read relative URL root from env
+      config.relative_url_root = ENV['RAILS_RELATIVE_URL_ROOT']
+
       # Load Redis config from config/redis.yml, if it exists
       config.cache_store = begin
         redis_config = Rails.application.config_for(:redis)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 Blacklight::Routes.send(:include, BlacklightRoutes)
 
 Rails.application.routes.draw do
+  unless ENV['RAILS_RELATIVE_URL_ROOT'].blank?
+    get '/', to: redirect(ENV['RAILS_RELATIVE_URL_ROOT'])
+  end
+
   scope ENV['RAILS_RELATIVE_URL_ROOT'] || '/' do
     root to: 'home#index'
     get 'search', to: 'portal#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,12 @@
 Blacklight::Routes.send(:include, BlacklightRoutes)
 
 Rails.application.routes.draw do
-  root to: 'home#index'
-  get 'search', to: 'portal#index'
+  scope ENV['RAILS_RELATIVE_URL_ROOT'] || '/' do
+    root to: 'home#index'
+    get 'search', to: 'portal#index'
 
-  blacklight_for :portal
+    blacklight_for :portal
 
-  resources :channels, only: [:show, :index]
+    resources :channels, only: [:show, :index]
+  end
 end


### PR DESCRIPTION
In production, set RELATIVE_URL_ROOT to /portal