### PR TITLE
Re #348: Remove redundant refs in asset manifests

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -9,11 +9,3 @@
 //
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
-//
-//= require jquery
-//= require jquery_ujs
-//= require turbolinks
-//
-// Required by Blacklight
-//= require blacklight/blacklight
-//= require_tree .

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -10,6 +10,5 @@
  * defined in the other CSS/SCSS files in this directory. It is generally better to create a new
  * file per style scope.
  *
- *= require blacklight
  *= require_self
  */

--- a/app/assets/stylesheets/blacklight.css.scss
+++ b/app/assets/stylesheets/blacklight.css.scss
@@ -1,5 +1,0 @@
-@import 'bootstrap-sprockets';
-
-@import 'bootstrap';
-
-@import 'blacklight/blacklight';


### PR DESCRIPTION
To improve deployment times on PaaS.