### PR TITLE
Re #344: Use URI for Redis cache store config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -72,9 +72,17 @@ module Europeana
 
       # Load Redis config from config/redis.yml, if it exists
       config.cache_store = begin
-        redis_config = Rails.application.config_for(:redis)
+        redis_config = Rails.application.config_for(:redis).symbolize_keys
         fail RuntimeError unless redis_config.present?
-        [:redis_store, redis_config]
+
+        uri = URI::Generic.build(scheme: 'redis')
+        uri.user = redis_config[:name]
+        uri.password = redis_config[:password]
+        uri.host = redis_config[:host]
+        uri.port = redis_config[:port]
+        uri.path = '/' + [redis_config[:db], redis_config[:namespace]].join('/')
+
+        [:redis_store, uri.to_s]
       rescue RuntimeError
         :null_store
       end

--- a/deploy/development/config/redis.yml
+++ b/deploy/development/config/redis.yml
@@ -2,3 +2,5 @@ development:
   host: <%= ENV['REDIS_HOST'] || 'localhost' %>
   port: <%= ENV['REDIS_PORT'] || 6379 %>
   name: <%= ENV['REDIS_NAME'] || 'redis' %>
+  db: 0
+  namespace: cache


### PR DESCRIPTION
As configuring by hash does not work on our PaaS.