### PR TITLE
Re #343: Enable FLAC player

### DIFF
--- a/app/views/portal/show.rb
+++ b/app/views/portal/show.rb
@@ -812,7 +812,7 @@ module Portal
         end
 
         if @mime_type == 'audio/flac'
-          item[:playable] = false
+          item[:playable] = true
         end
 
         if media_type == 'text' && @mime_type == 'text/plain; charset=utf-8'


### PR DESCRIPTION
Proxy service responds with required Access-Control-Expose-Headers header for Content-Type exposition.