### PR TITLE
Revert to Ruby 2.2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.2.3'
+ruby '2.2.2'
 gem 'rails', '4.2.4'
 
 gem 'europeana-styleguide',


### PR DESCRIPTION
Not possible to build Ruby 2.2.3 on A9s. Reverting Ruby to 2.2.2.