### PR TITLE
Re #473: Get the language settings form to work

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby '2.2.2'
 gem 'rails', '4.2.4'
 
 gem 'europeana-styleguide',
-  github: 'europeana/europeana-styleguide-ruby', ref: '5d142e8558'
+  github: 'europeana/europeana-styleguide-ruby', ref: '700b3d8'
 
 # Use a forked version of stache with downstream changes, until merged upstream
 # @see https://github.com/agoragames/stache/pulls/rwd

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,8 +12,8 @@ GIT
 
 GIT
   remote: git://github.com/europeana/europeana-styleguide-ruby.git
-  revision: 5d142e855896d9109559cf5d9ff024ce03e67657
-  ref: 5d142e8558
+  revision: 700b3d8993dae0af2436788593f06b9d21fc3e95
+  ref: 700b3d8
   specs:
     europeana-styleguide (0.1.0)
       activesupport (~> 4.0)

--- a/app/helpers/mustache_helper.rb
+++ b/app/helpers/mustache_helper.rb
@@ -346,8 +346,9 @@ module MustacheHelper
     {
       language: {
         form: {
-          action: root_url + '/settings/language',
-          method: 'PUT'
+          action: settings_language_path,
+          method: 'put',
+          form_authenticity_token: form_authenticity_token
         },
         title: t('site.settings.language.settings-label'),
         language_default: {


### PR DESCRIPTION
* Patternlab template updated to supply the required form fields to Rails: https://github.com/europeana/Europeana-Patternlab/commit/35962aeb194f79fc90c9a3f5e0ce6e548432025a
* However, instead of hard-coding these hidden inputs in the PL template, I recommend making it accept an arbitrary set of hidden input elements which it then outputs. This would decouple it from the Rails implementation.
* HTML submission of the language settings form now works.