### PR TITLE
Re #623: action caching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'rails_admin_globalize_field', github: 'rwd/rails_admin_globalize_field',
   branch: 'globalize-5-rails-4.2'
 
 gem 'aasm', '~> 4.2'
+gem 'actionpack-action_caching'
 gem 'blacklight', '~> 5.15'
 gem 'cancancan', '~> 1.12'
 gem 'clockwork', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,8 @@ GEM
       rack-test (~> 0.6.2)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionpack-action_caching (1.1.1)
+      actionpack (>= 4.0.0, < 5.0)
     actionview (4.2.4)
       activesupport (= 4.2.4)
       builder (~> 3.1)
@@ -543,6 +545,7 @@ PLATFORMS
 
 DEPENDENCIES
   aasm (~> 4.2)
+  actionpack-action_caching
   blacklight (~> 5.15)
   cancancan (~> 1.12)
   capybara (~> 2.4.0)

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -4,6 +4,18 @@ class BrowseController < ApplicationController
   include Catalog
   include Europeana::Styleguide
 
+  caches_action :colours,
+    expires_in: 1.day,
+    cache_path: Proc.new { I18n.locale.to_s + request.original_fullpath }
+
+  caches_action :new_content,
+    expires_in: 1.day,
+    cache_path: Proc.new { I18n.locale.to_s + request.original_fullpath }
+
+  caches_action :sources,
+    expires_in: 1.day,
+    cache_path: Proc.new { I18n.locale.to_s + request.original_fullpath }
+
   # GET /browse/colours
   def colours
     params = { query: '*:*', rows: 0, profile: 'minimal facets' }

--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -7,6 +7,11 @@ class ChannelsController < ApplicationController
 
   before_action :redirect_to_root, only: :show, if: proc { params[:id] == 'home' }
 
+  caches_action :show,
+    if: Proc.new { !request.format.json? },
+    expires_in: 1.hour,
+    cache_path: Proc.new { I18n.locale.to_s + request.original_fullpath }
+
   def index
     redirect_to_root
   end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,6 +4,10 @@ class HomeController < ApplicationController
   include Catalog
   include Europeana::Styleguide
 
+  caches_action :index,
+    expires_in: 1.hour,
+    cache_path: Proc.new { I18n.locale.to_s + request.original_fullpath }
+
   # GET /
   def index
     @channel = find_channel

--- a/app/controllers/portal_controller.rb
+++ b/app/controllers/portal_controller.rb
@@ -9,6 +9,20 @@ class PortalController < ApplicationController
 
   before_action :redirect_to_root, only: :index, unless: :has_search_parameters?
 
+  caches_action :index,
+    if: Proc.new { !request.format.json? },
+    expires_in: 1.day,
+    cache_path: Proc.new { I18n.locale.to_s + request.original_fullpath }
+
+  caches_action :show,
+    if: Proc.new { !request.format.json? && !params.key?(:debug) },
+    expires_in: 1.day,
+    cache_path: Proc.new { I18n.locale.to_s + request.original_fullpath }
+
+  caches_action :static,
+    expires_in: 1.hour,
+    cache_path: Proc.new { I18n.locale.to_s + request.original_fullpath }
+
   # GET /record/:id
   def show
     @response, @document = fetch(doc_id)

--- a/app/views/portal/show.rb
+++ b/app/views/portal/show.rb
@@ -17,6 +17,9 @@ module Portal
     end
 
     def navigation
+      # skip building item breadcrumb while action caching is in use
+      return helpers.navigation
+
       @mustache[:navigation] ||= begin
         query_params = current_search_session.try(:query_params) || {}
 

--- a/spec/features/object_spec.rb
+++ b/spec/features/object_spec.rb
@@ -1,41 +1,54 @@
 RSpec.feature 'Object page' do
   describe 'Navigation' do
     context 'with JS', js: true do
-      it 'expects working previous / next links' do
-        visit '/'
+      # No next/previous links when action caching is in use
+#       it 'expects working previous / next links' do
+#         visit '/'
 
-        sleep 3
+#         sleep 3
+
+#         fill_in('q', with: 'paris')
+
+#         click_button('Search')
+
+#         sleep 3
+
+#         find('.results-list ol.result-items li:first-child h1 a').click
+
+#         sleep 3
+
+#         expect(page).to have_css('.next')
+
+#         page_title_1 = page.title
+
+#         find('.next a').click
+
+#         sleep 3
+
+#         page_title_2 = page.title
+
+#         expect(page).to have_css('.next a')
+#         expect(page).to have_css('.previous a')
+
+#         expect(page_title_1).not_to eq(page_title_2)
+
+#         find('.previous a').click
+
+#         sleep 3
+
+#         expect(page.title).to eq(page_title_1)
+#       end
+      it 'expects no working previous / next links' do
+        visit '/'
 
         fill_in('q', with: 'paris')
 
         click_button('Search')
 
-        sleep 3
+        page.all('.results-list ol.result-items li h1 a')[2].click
 
-        find('.results-list ol.result-items li:first-child h1 a').click
-
-        sleep 3
-
-        expect(page).to have_css('.next')
-
-        page_title_1 = page.title
-
-        find('.next a').click
-
-        sleep 3
-
-        page_title_2 = page.title
-
-        expect(page).to have_css('.next a')
-        expect(page).to have_css('.previous a')
-
-        expect(page_title_1).not_to eq(page_title_2)
-
-        find('.previous a').click
-
-        sleep 3
-
-        expect(page.title).to eq(page_title_1)
+        expect(page).not_to have_css('.next')
+        expect(page).not_to have_css('.previous')
       end
     end
 


### PR DESCRIPTION
* action caching instead of fragment caching because the latter is not achievable with the Mustache template implementation
* required removal of next/previous and back to search links from object page as these vary per-request